### PR TITLE
Add k8s practice and docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,4 +32,5 @@ If you appreciate the effort, Please <img src="https://raw.githubusercontent.com
 ---
 - [@danirdd92](https://github.com/danirdd92)
 - [@guy-hemo](https://github.com/guy-hemo)
+- [@RanMarkovich](https://github.com/RanMarkovich)
 

--- a/Kubernetes/README-RunningLocalCluster.md
+++ b/Kubernetes/README-RunningLocalCluster.md
@@ -1,0 +1,140 @@
+# Local Kubernetes Development with kind
+
+This guide will help you set up a local Kubernetes cluster using kind and deploy a simple Nginx service with a static HTML file.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) installed
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) installed
+
+## Step 1: Create a kind Cluster
+
+```bash
+# Create a new kind cluster
+kind create cluster --name dev-cluster
+
+# Verify cluster is running
+kubectl cluster-info --context kind-dev-cluster
+```
+
+## Step 2: Create Deployment Files
+
+Create a new directory for your Kubernetes manifests:
+
+```bash
+mkdir k8s-manifests
+cd k8s-manifests
+```
+
+### Create nginx-deployment.yaml:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: html-content
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: html-content
+        configMap:
+          name: nginx-html
+```
+
+### Create nginx-service.yaml:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - port: 80
+    targetPort: 80
+  type: LoadBalancer
+```
+
+### Create nginx-html-configmap.yaml:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-html
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Welcome to Nginx!</title>
+    </head>
+    <body>
+        <h1>Hello from Nginx running in Kubernetes!</h1>
+        <p>This is a static HTML page served by Nginx in a kind cluster.</p>
+    </body>
+    </html>
+```
+
+## Step 3: Deploy the Application
+
+```bash
+# Apply all manifests
+kubectl apply -f nginx-html-configmap.yaml
+kubectl apply -f nginx-deployment.yaml
+kubectl apply -f nginx-service.yaml
+
+# Check deployment status
+kubectl get deployments
+kubectl get pods
+kubectl get services
+```
+
+## Step 4: Access the Application
+
+Since we're using kind, we need to forward the service port to access it:
+
+```bash
+# Forward the service port
+kubectl port-forward service/nginx-service 8080:80
+```
+
+Now you can access the Nginx service at http://localhost:8080
+
+## Cleanup
+
+To clean up your kind cluster:
+
+```bash
+kind delete cluster --name dev-cluster
+```
+
+## Troubleshooting
+
+- If you encounter any issues, check the pod logs:
+  ```bash
+  kubectl logs <pod-name>
+  ```
+- To describe a pod for more details:
+  ```bash
+  kubectl describe pod <pod-name>
+  ``` 

--- a/Kubernetes/README-k8sConfigMap.md
+++ b/Kubernetes/README-k8sConfigMap.md
@@ -1,0 +1,206 @@
+# Kubernetes ConfigMap Manifest Guide
+
+This guide explains the structure and components of a Kubernetes ConfigMap manifest.
+
+## Basic ConfigMap Structure
+
+A ConfigMap is a Kubernetes resource that stores non-confidential data in key-value pairs. Here's a breakdown of the key components:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: default
+data:
+  # Simple key-value pair
+  APP_COLOR: "blue"
+  APP_MODE: "production"
+  
+  # File-like key
+  game.properties: |
+    enemy.types=aliens,monsters
+    player.maximum-lives=5
+    
+  # Multi-line configuration
+  ui.properties: |
+    color.good=purple
+    color.bad=yellow
+    allow.textmode=true
+```
+
+## Key Components Explained
+
+### 1. Metadata Section
+- `apiVersion`: v1 (for ConfigMaps)
+- `kind`: ConfigMap
+- `metadata`: ConfigMap identification
+  - `name`: Unique name for the ConfigMap
+  - `namespace`: (Optional) Namespace where ConfigMap resides
+
+### 2. Data Section
+- `data`: Key-value pairs of configuration data
+  - Simple key-value pairs
+  - File-like keys with multi-line content
+  - Binary data (using `binaryData` field)
+
+## Creating ConfigMaps
+
+### 1. From Literal Values
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: literal-config
+data:
+  DB_HOST: "mysql"
+  DB_PORT: "3306"
+```
+
+### 2. From Files
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: file-config
+data:
+  # Content of config-file.txt
+  config-file.txt: |
+    line1
+    line2
+    line3
+```
+
+### 3. From Directory
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dir-config
+data:
+  file1.properties: |
+    key1=value1
+    key2=value2
+  file2.properties: |
+    key3=value3
+    key4=value4
+```
+
+## Using ConfigMaps in Pods
+
+### 1. As Environment Variables
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: env-pod
+spec:
+  containers:
+  - name: test-container
+    image: nginx
+    envFrom:
+    - configMapRef:
+        name: app-config
+```
+
+### 2. As Single Environment Variable
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: single-env-pod
+spec:
+  containers:
+  - name: test-container
+    image: nginx
+    env:
+    - name: APP_COLOR
+      valueFrom:
+        configMapKeyRef:
+          name: app-config
+          key: APP_COLOR
+```
+
+### 3. As Volume Mount
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-pod
+spec:
+  containers:
+  - name: test-container
+    image: nginx
+    volumeMounts:
+    - name: config-volume
+      mountPath: /etc/config
+  volumes:
+  - name: config-volume
+    configMap:
+      name: app-config
+```
+
+## Best Practices
+
+1. Use meaningful ConfigMap names
+2. Group related configuration together
+3. Use namespaces to organize ConfigMaps
+4. Keep ConfigMaps small and focused
+5. Use descriptive keys
+6. Consider using ConfigMap generators in CI/CD
+7. Implement proper RBAC for ConfigMap access
+8. Use ConfigMap updates carefully in production
+
+## Common Commands
+
+```bash
+# Create ConfigMap from literal values
+kubectl create configmap my-config --from-literal=key1=value1 --from-literal=key2=value2
+
+# Create ConfigMap from file
+kubectl create configmap my-config --from-file=path/to/file
+
+# Create ConfigMap from directory
+kubectl create configmap my-config --from-file=path/to/dir
+
+# View ConfigMap
+kubectl get configmap <configmap-name> -o yaml
+
+# Edit ConfigMap
+kubectl edit configmap <configmap-name>
+
+# Delete ConfigMap
+kubectl delete configmap <configmap-name>
+```
+
+## Troubleshooting
+
+1. Check ConfigMap exists:
+```bash
+kubectl get configmap <configmap-name>
+```
+
+2. View ConfigMap contents:
+```bash
+kubectl describe configmap <configmap-name>
+```
+
+3. Verify ConfigMap mounted in pod:
+```bash
+kubectl exec <pod-name> -- ls /etc/config
+```
+
+4. Check environment variables:
+```bash
+kubectl exec <pod-name> -- env | grep <config-key>
+```
+
+## Important Notes
+
+1. ConfigMaps are not encrypted
+2. Maximum size is 1MiB
+3. Changes to ConfigMap don't automatically update pods
+4. Consider using Secrets for sensitive data
+5. ConfigMaps are namespace-scoped
+6. Updates to ConfigMap may require pod restart
+7. Use ConfigMap volume for file-based configurations 

--- a/Kubernetes/README-k8sDeployment.md
+++ b/Kubernetes/README-k8sDeployment.md
@@ -1,0 +1,98 @@
+# Kubernetes Deployment Manifest Guide
+
+This guide explains the structure and components of a Kubernetes Deployment manifest.
+
+## Basic Deployment Structure
+
+A Kubernetes Deployment manifest is a YAML file that describes the desired state of your application. Here's a breakdown of the key components:
+
+
+## Key Components Explained
+
+### 1. Metadata Section
+- `apiVersion`: Specifies the API version (apps/v1 for Deployments)
+- `kind`: Defines the resource type (Deployment)
+- `metadata`: Contains identifying information
+  - `name`: Unique name for the deployment
+  - `labels`: Key-value pairs for resource identification
+
+### 2. Spec Section
+- `replicas`: Number of pod instances to maintain
+- `selector`: Defines how the deployment finds pods to manage
+  - `matchLabels`: Labels that pods must have to be managed by this deployment
+
+### 3. Template Section
+- `template`: Defines the pod template
+  - `metadata`: Labels for the pod
+  - `spec`: Container specifications
+    - `containers`: List of containers in the pod
+      - `name`: Container name
+      - `image`: Container image to use
+      - `ports`: Container ports to expose
+      - `volumeMounts`: Mount points for volumes
+    - `volumes`: Storage volumes available to containers
+
+## Common Fields to Add
+
+### Resource Limits
+```yaml
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+```
+
+### Environment Variables
+```yaml
+env:
+- name: ENV_VAR_NAME
+  value: "value"
+```
+
+### Health Checks
+```yaml
+livenessProbe:
+  httpGet:
+    path: /
+    port: 80
+  initialDelaySeconds: 30
+  periodSeconds: 10
+```
+
+## Best Practices
+
+1. Always specify resource limits and requests
+2. Use meaningful labels for better resource management
+3. Implement health checks (liveness and readiness probes)
+4. Use ConfigMaps or Secrets for configuration
+5. Consider using resource quotas in multi-tenant environments
+6. Implement proper security contexts
+7. Use imagePullPolicy: Always for production deployments
+
+## Common Commands
+
+```bash
+# Apply deployment
+kubectl apply -f deployment.yaml
+
+# Check deployment status
+kubectl get deployments
+
+# View deployment details
+kubectl describe deployment <deployment-name>
+
+# View pod status
+kubectl get pods
+
+# View deployment logs
+kubectl logs deployment/<deployment-name>
+
+# Scale deployment
+kubectl scale deployment <deployment-name> --replicas=3
+
+# Update deployment
+kubectl set image deployment/<deployment-name> nginx=nginx:1.19
+``` 

--- a/Kubernetes/README-k8sService.md
+++ b/Kubernetes/README-k8sService.md
@@ -1,0 +1,173 @@
+# Kubernetes Service Manifest Guide
+
+This guide explains the structure and components of a Kubernetes Service manifest.
+
+## Basic Service Structure
+
+A Kubernetes Service manifest is a YAML file that defines how to expose your application. Here's a breakdown of the key components:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: nginx
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  selector:
+    app: nginx
+```
+
+## Key Components Explained
+
+### 1. Metadata Section
+- `apiVersion`: v1 (for Services)
+- `kind`: Service
+- `metadata`: Service identification
+  - `name`: Unique name for the service
+  - `labels`: Key-value pairs for service identification
+
+### 2. Spec Section
+- `type`: Service type (ClusterIP, NodePort, LoadBalancer, or ExternalName)
+- `ports`: List of ports to expose
+  - `port`: Port exposed by the service
+  - `targetPort`: Port on the pod to forward to
+  - `protocol`: TCP, UDP, or SCTP
+  - `name`: Optional name for the port
+- `selector`: Labels to match pods for routing traffic
+
+## Service Types
+
+### 1. ClusterIP (Default)
+```yaml
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 80
+```
+- Only accessible within the cluster
+- Internal IP address assigned
+
+### 2. NodePort
+```yaml
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30007
+```
+- Exposes service on each node's IP
+- Accessible from outside the cluster
+- Port range: 30000-32767
+
+### 3. LoadBalancer
+```yaml
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 80
+```
+- Exposes service externally using cloud provider's load balancer
+- Automatically creates NodePort and ClusterIP
+
+### 4. ExternalName
+```yaml
+spec:
+  type: ExternalName
+  externalName: my.database.example.com
+```
+- Maps service to external DNS name
+- No selectors or ports needed
+
+## Advanced Configurations
+
+### Session Affinity
+```yaml
+spec:
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600
+```
+
+### Multiple Ports
+```yaml
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  - name: https
+    port: 443
+    targetPort: 443
+```
+
+### External IPs
+```yaml
+spec:
+  externalIPs:
+  - 192.168.1.100
+```
+
+## Best Practices
+
+1. Use meaningful service names and labels
+2. Choose appropriate service type based on access requirements
+3. Use named ports for better readability
+4. Implement proper network policies
+5. Consider using Ingress for HTTP/HTTPS traffic
+6. Use annotations for cloud provider specific configurations
+7. Implement proper security contexts
+
+## Common Commands
+
+```bash
+# Apply service
+kubectl apply -f service.yaml
+
+# Check service status
+kubectl get services
+
+# View service details
+kubectl describe service <service-name>
+
+# Get service endpoints
+kubectl get endpoints <service-name>
+
+# Expose deployment as service
+kubectl expose deployment <deployment-name> --port=80 --target-port=80
+
+# Port forward to service
+kubectl port-forward service/<service-name> 8080:80
+```
+
+## Troubleshooting
+
+1. Check service endpoints:
+```bash
+kubectl get endpoints <service-name>
+```
+
+2. Verify service selector matches pod labels:
+```bash
+kubectl get pods --show-labels
+```
+
+3. Check service events:
+```bash
+kubectl describe service <service-name>
+```
+
+4. Test service connectivity:
+```bash
+kubectl run test --image=busybox --rm -it -- wget -O- <service-name>:<port>
+``` 

--- a/Kubernetes/k8s-manifests/nginx-deployment.yaml
+++ b/Kubernetes/k8s-manifests/nginx-deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: html-content
+          mountPath: /usr/share/nginx/html
+      volumes:
+      - name: html-content
+        configMap:
+          name: nginx-html

--- a/Kubernetes/k8s-manifests/nginx-html-configmap.yaml
+++ b/Kubernetes/k8s-manifests/nginx-html-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-html
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Welcome to Nginx!</title>
+    </head>
+    <body>
+        <h1>Hello from Nginx running in Kubernetes!</h1>
+        <p>This is a static HTML page served by Nginx in a kind cluster.</p>
+    </body>
+    </html>

--- a/Kubernetes/k8s-manifests/nginx-service.yaml
+++ b/Kubernetes/k8s-manifests/nginx-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - port: 80
+    targetPort: 80
+  type: LoadBalancer


### PR DESCRIPTION
This PR consists of a Kubernetes folder with:
1. A main guide as a practice for setting up a local cluster and running Nginx webserver that serves a static HTML file
2. Documentations about the k8s manifests in this practice. 